### PR TITLE
Fix Solc compiler name to match regexp in foundry tests

### DIFF
--- a/crates/compilers/src/compilers/resolc/compiler.rs
+++ b/crates/compilers/src/compilers/resolc/compiler.rs
@@ -66,7 +66,7 @@ impl Compiler for Resolc {
 
 impl SimpleCompilerName for Resolc {
     fn compiler_name_default() -> std::borrow::Cow<'static, str> {
-        "resolc and solc".into()
+        "Resolc and Solc".into()
     }
 }
 


### PR DESCRIPTION
Solc should start with an uppercase letter to match the regex pattern in foundry tests.