### PR TITLE
(fix) Add compiler version to the reporter

### DIFF
--- a/crates/compilers/src/compilers/mod.rs
+++ b/crates/compilers/src/compilers/mod.rs
@@ -338,6 +338,9 @@ pub trait Compiler: Send + Sync + Clone {
     /// Returns compiler name used by reporters to display output during compilation.
     fn compiler_name(&self, input: &Self::Input) -> Cow<'static, str>;
 
+    /// Returns compiler version used by reporters to display output during compilation.
+    fn compiler_version(&self, input: &Self::Input) -> Version;
+
     /// Main entrypoint for the compiler. Compiles given input into [CompilerOutput]. Takes
     /// ownership over the input and returns back version with potential modifications made to it.
     /// Returned input is always the one which was seen by the binary.

--- a/crates/compilers/src/compilers/resolc/compiler.rs
+++ b/crates/compilers/src/compilers/resolc/compiler.rs
@@ -33,6 +33,10 @@ impl Compiler for Resolc {
     type Settings = SolcSettings;
     type Language = SolcLanguage;
 
+    fn compiler_version(&self, _input: &Self::Input) -> Version {
+        self.resolc_version.clone()
+    }
+
     fn compiler_name(&self, _input: &Self::Input) -> std::borrow::Cow<'static, str> {
         Self::compiler_name_default()
     }

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -51,6 +51,10 @@ impl Compiler for SolcCompiler {
     type Language = SolcLanguage;
     type CompilerContract = Contract;
 
+    fn compiler_version(&self, input: &Self::Input) -> Version {
+        input.version().clone()
+    }
+
     fn compiler_name(&self, _input: &Self::Input) -> Cow<'static, str> {
         Self::compiler_name_default()
     }

--- a/crates/compilers/src/compilers/vyper/mod.rs
+++ b/crates/compilers/src/compilers/vyper/mod.rs
@@ -1,5 +1,5 @@
 use self::{input::VyperVersionedInput, parser::VyperParsedSource};
-use super::{Compiler, CompilerOutput, Language, SimpleCompilerName};
+use super::{Compiler, CompilerInput, CompilerOutput, Language, SimpleCompilerName};
 pub use crate::artifacts::vyper::{VyperCompilationError, VyperInput, VyperOutput, VyperSettings};
 use core::fmt;
 use foundry_compilers_artifacts::{sources::Source, Contract};
@@ -212,6 +212,10 @@ impl Compiler for Vyper {
     type Input = VyperVersionedInput;
     type Language = VyperLanguage;
     type CompilerContract = Contract;
+
+    fn compiler_version(&self, input: &Self::Input) -> Version {
+        input.version().clone()
+    }
 
     fn compiler_name(&self, _input: &Self::Input) -> Cow<'static, str> {
         Self::compiler_name_default()

--- a/crates/compilers/src/report/mod.rs
+++ b/crates/compilers/src/report/mod.rs
@@ -365,7 +365,7 @@ impl Reporter for BasicStdoutReporter {
                 .filter(|str| !str.is_empty())
                 .map(|x| x.trim())
                 .zip(versions)
-                .map(|(name, version)| format!("{name}@{version}"))
+                .map(|(name, version)| format!("{name} v{version}"))
                 .collect::<Vec<_>>()
                 .join(", ");
             println!("Compiling {} files with {}", dirty_files.len(), names);
@@ -389,7 +389,7 @@ impl Reporter for BasicStdoutReporter {
                 .filter(|str| !str.is_empty())
                 .map(|x| x.trim())
                 .zip(versions)
-                .map(|(name, version)| format!("{name}@{version}"))
+                .map(|(name, version)| format!("{name} v{version}"))
                 .collect::<Vec<_>>()
                 .join(", ");
             println!("{names} Finished in {duration:.2?}");

--- a/crates/compilers/src/report/mod.rs
+++ b/crates/compilers/src/report/mod.rs
@@ -111,10 +111,36 @@ pub trait Reporter: 'static + std::fmt::Debug {
     ) {
     }
 
+    /// Callback invoked right before [Compiler::compile] is called
+    ///
+    /// This contains the [Compiler] its [Version] and all files that triggered the compile job. The
+    /// dirty files are only provided to give a better feedback what was actually compiled.
+    ///
+    /// [Compiler]: crate::compilers::Compiler
+    /// [Compiler::compile]: crate::compilers::Compiler::compile
+    fn on_multicompiler_spawn(
+        &self,
+        _compiler_name: &str,
+        _versions: &[Version],
+        _dirty_files: &[PathBuf],
+    ) {
+    }
+
     /// Invoked with the `CompilerOutput` if [`Compiler::compile()`] was successful
     ///
     /// [`Compiler::compile()`]: crate::compilers::Compiler::compile
     fn on_compiler_success(&self, _compiler_name: &str, _version: &Version, _duration: &Duration) {}
+
+    /// Invoked with the `CompilerOutput` if [`Compiler::compile()`] was successful
+    ///
+    /// [`Compiler::compile()`]: crate::compilers::Compiler::compile
+    fn on_multicompiler_success(
+        &self,
+        _compiler_name: &str,
+        _versions: &[Version],
+        _duration: &Duration,
+    ) {
+    }
 
     /// Invoked before a new compiler version is installed
     fn on_solc_installation_start(&self, _version: &Version) {}
@@ -172,12 +198,12 @@ impl dyn Reporter {
     }
 }
 
-pub(crate) fn compiler_spawn(compiler_name: &str, version: &Version, dirty_files: &[PathBuf]) {
-    get_default(|r| r.reporter.on_compiler_spawn(compiler_name, version, dirty_files));
+pub(crate) fn compiler_spawn(compiler_name: &str, version: &[Version], dirty_files: &[PathBuf]) {
+    get_default(|r| r.reporter.on_multicompiler_spawn(compiler_name, version, dirty_files));
 }
 
-pub(crate) fn compiler_success(compiler_name: &str, version: &Version, duration: &Duration) {
-    get_default(|r| r.reporter.on_compiler_success(compiler_name, version, duration));
+pub(crate) fn compiler_success(compiler_name: &str, version: &[Version], duration: &Duration) {
+    get_default(|r| r.reporter.on_multicompiler_success(compiler_name, version, duration));
 }
 
 #[allow(dead_code)]
@@ -322,21 +348,50 @@ impl Reporter for BasicStdoutReporter {
     ///
     /// [`Compiler::compile()`]: crate::compilers::Compiler::compile
     fn on_compiler_spawn(&self, compiler_name: &str, version: &Version, dirty_files: &[PathBuf]) {
-        println!(
-            "Compiling {} files with {} {}.{}.{}",
-            dirty_files.len(),
-            compiler_name,
-            version.major,
-            version.minor,
-            version.patch
-        );
+        println!("Compiling {} files with {} {}", dirty_files.len(), compiler_name, version);
+    }
+
+    fn on_multicompiler_spawn(
+        &self,
+        compiler_name: &str,
+        versions: &[Version],
+        dirty_files: &[PathBuf],
+    ) {
+        if let [version] = versions {
+            self.on_compiler_spawn(compiler_name, version, dirty_files);
+        } else {
+            let names = compiler_name
+                .split("and")
+                .filter(|str| !str.is_empty())
+                .map(|x| x.trim())
+                .zip(versions)
+                .map(|(name, version)| format!("{}@{}", name, version))
+                .join(", ");
+            println!("Compiling {} files with {}", dirty_files.len(), names);
+        }
     }
 
     fn on_compiler_success(&self, compiler_name: &str, version: &Version, duration: &Duration) {
-        println!(
-            "{} {}.{}.{} finished in {duration:.2?}",
-            compiler_name, version.major, version.minor, version.patch
-        );
+        println!("{} {} finished in {duration:.2?}", compiler_name, version);
+    }
+    fn on_multicompiler_success(
+        &self,
+        compiler_name: &str,
+        versions: &[Version],
+        duration: &Duration,
+    ) {
+        if let [version] = versions {
+            self.on_compiler_success(compiler_name, version, duration);
+        } else {
+            let names = compiler_name
+                .split("and")
+                .filter(|str| !str.is_empty())
+                .map(|x| x.trim())
+                .zip(versions)
+                .map(|(name, version)| format!("{}@{}", name, version))
+                .join(", ");
+            println!("{} Finished in {duration:.2?}", names);
+        }
     }
 
     /// Invoked before a new compiler is installed

--- a/crates/compilers/src/report/mod.rs
+++ b/crates/compilers/src/report/mod.rs
@@ -366,6 +366,7 @@ impl Reporter for BasicStdoutReporter {
                 .map(|x| x.trim())
                 .zip(versions)
                 .map(|(name, version)| format!("{}@{}", name, version))
+                .collect::<Vec<_>>()
                 .join(", ");
             println!("Compiling {} files with {}", dirty_files.len(), names);
         }
@@ -389,6 +390,7 @@ impl Reporter for BasicStdoutReporter {
                 .map(|x| x.trim())
                 .zip(versions)
                 .map(|(name, version)| format!("{}@{}", name, version))
+                .collect::<Vec<_>>()
                 .join(", ");
             println!("{} Finished in {duration:.2?}", names);
         }

--- a/crates/compilers/src/report/mod.rs
+++ b/crates/compilers/src/report/mod.rs
@@ -365,7 +365,7 @@ impl Reporter for BasicStdoutReporter {
                 .filter(|str| !str.is_empty())
                 .map(|x| x.trim())
                 .zip(versions)
-                .map(|(name, version)| format!("{}@{}", name, version))
+                .map(|(name, version)| format!("{name}@{version}"))
                 .collect::<Vec<_>>()
                 .join(", ");
             println!("Compiling {} files with {}", dirty_files.len(), names);
@@ -373,7 +373,7 @@ impl Reporter for BasicStdoutReporter {
     }
 
     fn on_compiler_success(&self, compiler_name: &str, version: &Version, duration: &Duration) {
-        println!("{} {} finished in {duration:.2?}", compiler_name, version);
+        println!("{compiler_name} {version} finished in {duration:.2?}");
     }
     fn on_multicompiler_success(
         &self,
@@ -389,10 +389,10 @@ impl Reporter for BasicStdoutReporter {
                 .filter(|str| !str.is_empty())
                 .map(|x| x.trim())
                 .zip(versions)
-                .map(|(name, version)| format!("{}@{}", name, version))
+                .map(|(name, version)| format!("{name}@{version}"))
                 .collect::<Vec<_>>()
                 .join(", ");
-            println!("{} Finished in {duration:.2?}", names);
+            println!("{names} Finished in {duration:.2?}");
         }
     }
 


### PR DESCRIPTION
### Description 

Adds compiler versions to the reporter output if there are more than one avaialble. 

new example output: 
```bash 
---- can_purge_obsolete_artifacts::case_1_solc stdout ----
Compiling 1 files with Solc 0.8.10
Solc 0.8.10 finished in 11.26ms
Compiling 1 files with Solc 0.8.13
Solc 0.8.13 finished in 9.58ms

---- can_purge_obsolete_artifacts::case_2_resolc stdout ----
Compiling 1 files with Resolc@0.1.0-dev.12, Solc@0.8.10
Resolc@0.1.0-dev.12, Solc@0.8.10 Finished in 307.48ms
Compiling 1 files with Resolc@0.1.0-dev.12, Solc@0.8.13
Resolc@0.1.0-dev.12, Solc@0.8.13 Finished in 266.17ms
```