### PR TITLE
Fixup Bytecode handling

### DIFF
--- a/crates/artifacts/resolc/src/lib.rs
+++ b/crates/artifacts/resolc/src/lib.rs
@@ -3,7 +3,7 @@
 use std::{collections::BTreeMap, path::PathBuf};
 
 pub mod contract;
-use alloy_primitives::hex;
+use alloy_primitives::{hex::FromHex, Bytes};
 use contract::ResolcContract;
 use foundry_compilers_artifacts_solc::{
     Bytecode, BytecodeObject, DeployedBytecode, Error, FileToContractsMap, SourceFile,
@@ -98,7 +98,7 @@ impl ResolcBytecode {
 
 impl From<ResolcBytecode> for Bytecode {
     fn from(value: ResolcBytecode) -> Self {
-        let object = hex::decode(value.object).expect("Value wasn't correctly encoded").into();
+        let object = Bytes::from_hex(value.object).expect("Value wasn't correctly encoded");
         Self {
             function_debug_data: BTreeMap::new(),
             object: BytecodeObject::Bytecode(object),

--- a/crates/artifacts/resolc/src/lib.rs
+++ b/crates/artifacts/resolc/src/lib.rs
@@ -3,6 +3,7 @@
 use std::{collections::BTreeMap, path::PathBuf};
 
 pub mod contract;
+use alloy_primitives::hex;
 use contract::ResolcContract;
 use foundry_compilers_artifacts_solc::{
     Bytecode, BytecodeObject, DeployedBytecode, Error, FileToContractsMap, SourceFile,
@@ -97,9 +98,10 @@ impl ResolcBytecode {
 
 impl From<ResolcBytecode> for Bytecode {
     fn from(value: ResolcBytecode) -> Self {
+        let object = hex::decode(value.object).expect("Value wasn't correctly encoded").into();
         Self {
             function_debug_data: BTreeMap::new(),
-            object: BytecodeObject::Bytecode(value.object.into()),
+            object: BytecodeObject::Bytecode(object),
             opcodes: None,
             source_map: None,
             generated_sources: vec![],

--- a/crates/compilers/tests/project.rs
+++ b/crates/compilers/tests/project.rs
@@ -4537,3 +4537,36 @@ contract A { }
         );
     });
 }
+
+#[rstest]
+#[case::resolc(resolc())]
+fn can_compile_with_right_output(#[case] compiler: MultiCompiler) {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
+    let paths = ProjectPathsConfig::builder().sources(root.join("src")).lib(root.join("lib"));
+
+    let handler = ConfigurableArtifacts {
+        additional_values: ExtraOutputValues { metadata: true, ..Default::default() },
+        ..Default::default()
+    };
+
+    let settings = handler.solc_settings();
+    let mut project =
+        TempProject::with_artifacts(paths, handler).unwrap().with_solc_settings(settings);
+    project.project_mut().compiler = compiler;
+
+    let compiled = project.compile().unwrap();
+    let artifact = compiled.find_first("Dapp").unwrap();
+
+    // Line below should fail as it tests non-hex encoded prefix for the bytecode.
+    // assert!(artifact.bytecode.clone().unwrap().object.as_bytes().unwrap().starts_with(b"505"));
+
+    assert!(artifact
+        .bytecode
+        .clone()
+        .unwrap()
+        .object
+        .as_bytes()
+        .unwrap()
+        .to_string()
+        .starts_with("0x505"));
+}

--- a/crates/compilers/tests/project.rs
+++ b/crates/compilers/tests/project.rs
@@ -4538,28 +4538,15 @@ contract A { }
     });
 }
 
-#[rstest]
-#[case::resolc(resolc())]
-fn can_compile_with_right_output(#[case] compiler: MultiCompiler) {
+#[test]
+fn can_compile_with_right_output() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
     let paths = ProjectPathsConfig::builder().sources(root.join("src")).lib(root.join("lib"));
+    let mut project = TempProject::<MultiCompiler, ConfigurableArtifacts>::new(paths).unwrap();
 
-    let handler = ConfigurableArtifacts {
-        additional_values: ExtraOutputValues { metadata: true, ..Default::default() },
-        ..Default::default()
-    };
-
-    let settings = handler.solc_settings();
-    let mut project =
-        TempProject::with_artifacts(paths, handler).unwrap().with_solc_settings(settings);
-    project.project_mut().compiler = compiler;
-
+    project.project_mut().compiler = resolc();
     let compiled = project.compile().unwrap();
     let artifact = compiled.find_first("Dapp").unwrap();
-
-    // Line below should fail as it tests non-hex encoded bytecode for the hex-encoded prefix.
-    // assert!(artifact.bytecode.clone().unwrap().object.as_bytes().unwrap().starts_with(b"505"));
-
     assert!(artifact
         .bytecode
         .clone()
@@ -4568,5 +4555,5 @@ fn can_compile_with_right_output(#[case] compiler: MultiCompiler) {
         .as_bytes()
         .unwrap()
         .to_string()
-        .starts_with("0x505"));
+        .starts_with("0x50564d"));
 }

--- a/crates/compilers/tests/project.rs
+++ b/crates/compilers/tests/project.rs
@@ -4557,7 +4557,7 @@ fn can_compile_with_right_output(#[case] compiler: MultiCompiler) {
     let compiled = project.compile().unwrap();
     let artifact = compiled.find_first("Dapp").unwrap();
 
-    // Line below should fail as it tests non-hex encoded prefix for the bytecode.
+    // Line below should fail as it tests non-hex encoded bytecode for the hex-encoded prefix.
     // assert!(artifact.bytecode.clone().unwrap().object.as_bytes().unwrap().starts_with(b"505"));
 
     assert!(artifact


### PR DESCRIPTION
### Description 

Correctly decode the Bytecode received from `resolc` which is encoded in [`hex`](https://github.com/paritytech/revive/blob/66f9a4d64f36777e6a632736121c1cc57d33de16/crates/solidity/src/build/contract.rs#L120). 
