### PR TITLE
Partially revert #12

### DIFF
--- a/crates/compilers/src/report/mod.rs
+++ b/crates/compilers/src/report/mod.rs
@@ -389,7 +389,7 @@ impl Reporter for BasicStdoutReporter {
                 .filter(|str| !str.is_empty())
                 .map(|x| x.trim())
                 .zip(versions)
-                .map(|(name, version)| format!("{name} {version}"))
+                .map(|(name, version)| format!("{name} v{version}"))
                 .collect::<Vec<_>>()
                 .join(", ");
             println!("{names} finished in {duration:.2?}");


### PR DESCRIPTION
Partially reverts #12 

Regex in test never matches the version output, notice no `v` prefix.

```bash 
Resolc <version>, Solc <version>
```

[see](https://github.com/paritytech/foundry-revive/blob/upstream-merge/crates/test-utils/src/util.rs#L1026)